### PR TITLE
Fixing Linting Issue

### DIFF
--- a/.github/workflows/python-linter.yml
+++ b/.github/workflows/python-linter.yml
@@ -14,9 +14,9 @@ jobs:
       uses: actions/checkout@v4.1.0
 
     - name: Set up Python
-      uses: actions/setup-python@v4.7.1
+      uses: actions/setup-python@v6.0.0
       with:
-        python-version: 3.8
+        python-version: '3.12'
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Use of Python version 3.8 limits the new feature introduced during and after 3.10. This fix should resolve the linting issue caused due to older python versions that doesn't support newer features.