### PR TITLE
Automatic file backup

### DIFF
--- a/Automatic_file_backup/ReadMe.md
+++ b/Automatic_file_backup/ReadMe.md
@@ -1,0 +1,65 @@
+# Daily Folder Backup
+
+A tiny Python script that automatically backs up a folder to a destination directory once a day, timestamped by date.
+
+## Features
+
+- Runs continuously in the background and triggers a backup every day at a set time
+- Copies an entire folder tree using `shutil.copytree`
+- Names each backup by the date it was created (e.g. `2026-07-16`), so you get one snapshot per day
+- Skips silently (with a message) if a backup for that day already exists, instead of crashing
+
+## Requirements
+
+- Python 3.7+
+- [`schedule`](https://pypi.org/project/schedule/) library
+
+Install the dependency with:
+
+```bash
+pip install schedule
+```
+
+## Configuration
+
+Open the script and set the two path variables at the top:
+
+```python
+source_dir = "/path/to/folder/to/back/up"
+destination_dir = "/path/to/where/backups/go"
+```
+
+By default, the job runs daily at `12:00` (24-hour format). To change the time, edit this line:
+
+```python
+schedule.every().day.at("12:00").do(...)
+```
+
+## Usage
+
+Run the script and leave it running (e.g. in a terminal, `tmux`/`screen` session, or as a background service):
+
+```bash
+python automatic_file_backup.py
+```
+
+Each day at the scheduled time, it will create a new folder inside `destination_dir` named after the current date, containing a full copy of `source_dir`.
+
+## How it works
+
+1. `schedule` checks every 60 seconds whether it's time to run the backup job.
+2. When triggered, `copy_folder_to_directionary()` builds a destination path using today's date.
+3. `shutil.copytree` recursively copies the source folder into that dated destination.
+4. If a folder for that date already exists, a `FileExistsError` is caught and a message is printed instead of overwriting or crashing.
+
+## Limitations & ideas for contribution
+
+- Only one backup per day is supported (running twice in a day just logs "already exists")
+- No cleanup/rotation of old backups — the destination folder will grow indefinitely
+- No logging to a file, only `print` statements
+- Could be extended with:
+  - Configurable backup retention (e.g. delete backups older than N days)
+  - Support for multiple source folders
+  - Compression (zip/tar) instead of a raw folder copy
+  - A config file or CLI args instead of hardcoded paths
+  - Proper logging via Python's `logging` module

--- a/Automatic_file_backup/automatic_file_backup.py
+++ b/Automatic_file_backup/automatic_file_backup.py
@@ -1,0 +1,28 @@
+import time
+import schedule
+import datetime
+import shutil
+import os
+
+source_dir = ""        # Set this to the folder you want to back up
+destination_dir = ""   # Set this to where backups should be saved
+
+
+def copy_folder_to_directionary(source, dest):
+    today = datetime.date.today()
+    dest_dir = os.path.join(dest, str(today))
+
+    try:
+        shutil.copytree(source, dest_dir)
+        print(f"Folder copied to: {dest_dir}")
+
+    except FileExistsError:
+        print(f"folderalready exists in {dest}")
+
+
+schedule.every().day.at("12:00").do(lambda: copy_folder_to_directionary(source_dir, destination_dir)
+                                    )
+
+while True:
+    schedule.run_pending()
+    time.sleep(60)


### PR DESCRIPTION
Add scheduled daily folder backup script
This adds a small standalone script that automates daily backups of a folder using the `schedule` library.

What it does
- Runs continuously and copies a source folder to a destination directory once a day at a configurable time
- Names each backup by date (e.g. `2026-07-16`) so each day's snapshot is kept separately
- Gracefully handles the case where a backup for the current day already exists, instead of throwing an unhandled error

Why
Useful as a lightweight, dependency-light way to keep periodic snapshots of a folder (configs, project files, etc.) without needing a full backup tool or cron setup on systems where that's inconvenient.

How to test
1. `pip install schedule`
2. Set `source_dir` and `destination_dir` at the top of the script
3. Temporarily change the scheduled time to a few minutes from now
4. Run the script and confirm a dated folder appears in `destination_dir` with the source contents copied

**Notes / follow-ups**
- No backup rotation/cleanup yet — old backups accumulate over time
- Only supports one source folder per run
- Included a README documenting usage, configuration, and possible future improvements (rotation, compression, CLI config, logging)